### PR TITLE
Revert "Disable echonl after every command"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -31,14 +31,6 @@ zstyle :compinstall filename "$HOME/.zshrc"
 autoload -Uz compinit && compinit
 zstyle ':completion:*' menu select
 
-# The Dart VM conflates echo (echo typed characters) and echonl (echo
-# newlines). Until fixed, turn off echonl after every command.
-#
-# See: https://github.com/dart-lang/sdk/issues/30318
-precmd() {
-  stty -echonl
-}
-
 # Current git branch (for prompt)
 git_branch() {
   local branch="$(git rev-parse --abbrev-ref HEAD 2> /dev/null)"


### PR DESCRIPTION
The bug in the Dart VM that resulted in the echonl TTY setting being
incorrectly set on exit (https://github.com/dart-lang/sdk/issues/30318)
was fixed by https://dart-review.googlesource.com/c/sdk/+/45746.

This reverts commit b200830892b64035ee5c6c7478a911c6f134f630.